### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/springuper/grunt-git-newer#readme",
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": ">=0.4.1"
   },
   "devDependencies": {
     "grunt": "0.4.5",


### PR DESCRIPTION
Hey, 

Just wanted to update the `peerDependencies` for this plugin so it will work with Grunt 1.0. See [here](http://gruntjs.com/blog/2016-04-04-grunt-1.0.0-released#peer-dependencies).

Thanks!
